### PR TITLE
affinegap 1.12.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 2bf275b6d8b083bdb32b16fd4e4a55025eaad2ef6f325d3f0b0cdf8253608aaf
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,9 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/affinegap-{{ version }}.tar.gz
-  sha256: 02faa7579df8d98beafd40bb924b7a3a9d4e42edf6938e297366903054e4ef61
+  # Use upstream archive tarball for tests
+  url: https://github.com/dedupeio/affinegap/archive/refs/tags/v1.12.tar.gz
+  sha256: 2bf275b6d8b083bdb32b16fd4e4a55025eaad2ef6f325d3f0b0cdf8253608aaf
 
 build:
   number: 2
@@ -27,12 +28,16 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - affinegap
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://github.com/dedupeio/affinegap

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 2
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -21,22 +21,30 @@ requirements:
     - cython
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
 
 test:
   imports:
     - affinegap
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
-  home: https://github.com/datamade/affinegap
+  home: https://github.com/dedupeio/affinegap
   summary: A Cython implementation of the affine gap string distance
+  description: |
+    A Cython implementation of the affine gap penalty string distance
+    also known as the Smith–Waterman algorithm
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://github.com/dedupeio/affinegap
+  dev_url: https://github.com/dedupeio/affinegap
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   # Use upstream archive tarball for tests
-  url: https://github.com/dedupeio/affinegap/archive/refs/tags/v1.12.tar.gz
+  url: https://github.com/dedupeio/affinegap/archive/refs/tags/v{{ version}}.tar.gz
   sha256: 2bf275b6d8b083bdb32b16fd4e4a55025eaad2ef6f325d3f0b0cdf8253608aaf
 
 build:


### PR DESCRIPTION
affinegap 1.12.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4960]
- dev_url:        https://github.com/dedupeio/affinegap/tree/v1.12
- conda_forge:    https://github.com/conda-forge/affinegap-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/affinegap/1.12.0
- pypi inspector: https://inspector.pypi.io/project/affinegap/1.12.0

### Explanation of changes:

- basic build
- switch to archive tarball for tests


[PKG-4960]: https://anaconda.atlassian.net/browse/PKG-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ